### PR TITLE
[COOK-1958] Use chef_gem to install dynect_rest gem.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,10 +17,4 @@
 # limitations under the License.
 #
 
-# Install dynect in advance
-r = gem_package "dynect_rest" do
-  action :nothing
-end
-r.run_action(:upgrade)
-require 'rubygems'
-Gem.clear_paths
+chef_gem "dynect_rest"


### PR DESCRIPTION
The chef_gem resource that the gem is installed correctly for use
inside recipes.  This change makes the cookbook incompatible with
version of Chef that lack the chef_gem resource.
