### PR TITLE
[COOK-2382] Fix foodcritic warnings.

### DIFF
--- a/recipes/a_record.rb
+++ b/recipes/a_record.rb
@@ -19,13 +19,13 @@
 
 include_recipe 'dynect'
 
-dynect_rr node[:hostname] do
+dynect_rr node["hostname"] do
   record_type "A"
-  rdata({ "address" => node[:ipaddress] })
-  fqdn "#{node[:hostname]}.#{node[:dynect][:domain]}"
-  customer node[:dynect][:customer]
-  username node[:dynect][:username]
-  password node[:dynect][:password]
-  zone     node[:dynect][:zone]
+  rdata({ "address" => node["ipaddress"] })
+  fqdn "#{node["hostname"]}.#{node["dynect"]["domain"]}"
+  customer node["dynect"]["customer"]
+  username node["dynect"]["username"]
+  password node["dynect"]["password"]
+  zone     node["dynect"]["zone"]
   action :update
 end

--- a/recipes/ec2.rb
+++ b/recipes/ec2.rb
@@ -20,10 +20,10 @@
 include_recipe 'dynect'
 
 # "i-17734b7c.example.com" => ec2.public_hostname
-dynect_rr node[:ec2][:instance_id] do
+dynect_rr node["ec2"]["instance_id"] do
   record_type "CNAME"
-  fqdn "#{node[:ec2][:instance_id]}.#{node["dynect"]["domain"]}"
-  rdata({ "cname" => "#{node[:ec2][:public_hostname]}." })
+  fqdn "#{node["ec2"]["instance_id"]}.#{node["dynect"]["domain"]}"
+  rdata({ "cname" => "#{node["ec2"]["public_hostname"]}." })
   customer node["dynect"]["customer"]
   username node["dynect"]["username"]
   password node["dynect"]["password"]
@@ -37,7 +37,7 @@ new_fqdn = "#{new_hostname}.#{node["dynect"]["domain"]}"
 dynect_rr new_hostname do
   record_type "CNAME"
   fqdn new_fqdn
-  rdata({ "cname" => "#{node[:ec2][:public_hostname]}." })
+  rdata({ "cname" => "#{node["ec2"]["public_hostname"]}." })
   customer node["dynect"]["customer"]
   username node["dynect"]["username"]
   password node["dynect"]["password"]
@@ -57,7 +57,7 @@ end
 ruby_block "edit etc hosts" do
   block do
     rc = Chef::Util::FileEdit.new("/etc/hosts")
-    new_hosts_entry = "#{node['ec2']['local_ipv4']} #{new_fqdn} #{new_hostname}"
+    new_hosts_entry = "#{node["ec2"]["local_ipv4"]} #{new_fqdn} #{new_hostname}"
     rc.insert_line_if_no_match(new_hosts_entry, new_hosts_entry)
     rc.write_file
   end
@@ -68,8 +68,8 @@ execute "hostname --file /etc/hostname" do
 end
 
 file "/etc/hostname" do
-  content "#{new_hostname}"
-  notifies :run, resources(:execute => "hostname --file /etc/hostname"), :immediately
+  content new_hostname
+  notifies :run, "execute[hostname --file /etc/hostname]", :immediately
 end
 
 node.automatic_attrs["hostname"] = new_hostname

--- a/resources/rr.rb
+++ b/resources/rr.rb
@@ -28,3 +28,5 @@ attribute :username, :kind_of => String
 attribute :password, :kind_of => String
 attribute :customer, :kind_of => String
 attribute :zone, :kind_of => String
+
+default_action :create


### PR DESCRIPTION
- Use strings rather than symbols when accessing attrs,
- Declare a default action, and
- Use new notification sytle.
