### PR TITLE
Remove warn spam of chef_gem compile_time

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,5 +19,7 @@
 
 # Install dynect gem for usage within Chef runs
 chef_gem 'dynect_rest' do
+  # as per https://www.chef.io/blog/2015/02/17/chef-12-1-0-chef_gem-resource-warnings/
+  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
   action :install
 end


### PR DESCRIPTION
As per
https://www.chef.io/blog/2015/02/17/chef-12-1-0-chef_gem-resource-warnings/
community cookbooks should have a PR like below:

chef_gem "aws-sdk" do
  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
end
