### PR TITLE
Databag support for storing Dynect credentials

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,5 +25,21 @@
 # set[:dynect][:zone] = ""
 # set[:dynect][:domain] = ""
 #
+# Instead of setting the attributes directly, you can use
+# an encrypted databag instead. If :data_bag_name is not empty,
+# the cookbook will switch to using the data bag method.
+#
+# set[:dynect][:data_bag_name] = 'passwords'
+# set[:dynect][:data_bag_item] = 'dynect'
+#
+# The data bag item would be formatted like this:
+#
+# {
+#   "id": "dynect",
+#   "customer": "",
+#   "username": "",
+#   "password": ""
+# }
+#
 # set[:dynect][:ec2][:type] = "ec2"
 # set[:dynect][:ec2][:env]  = "prod"

--- a/libraries/dynect_helper.rb
+++ b/libraries/dynect_helper.rb
@@ -1,0 +1,18 @@
+module Dynect
+  module Helper
+    def credential_source
+      if node['dynect']['data_bag_name']
+        Chef::EncryptedDataBagItem.load(
+          node['dynect']['data_bag_name'],
+          node['dynect']['data_bag_item']
+        )
+      else
+        node['dynect']
+      end
+    end
+
+    def get_credentials
+      credential_source.select { |key, _| %w(customer username password).include? key }
+    end
+  end
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,17 @@
+if defined?(ChefSpec)
+  def create_dynect_rr(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:dynect_rr, :create, resource_name)
+  end
+
+  def update_dynect_rr(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:dynect_rr, :update, resource_name)
+  end
+
+  def replace_dynect_rr(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:dynect_rr, :replace, resource_name)
+  end
+
+  def delete_dynect_rr(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:dynect_rr, :delete, resource_name)
+  end
+end

--- a/recipes/a_record.rb
+++ b/recipes/a_record.rb
@@ -18,14 +18,17 @@
 #
 
 include_recipe 'dynect'
+extend Dynect::Helper
+
+creds = get_credentials
 
 dynect_rr node['hostname'] do
   record_type 'A'
   rdata('address' => node['ipaddress'])
   fqdn "#{node['hostname']}.#{node['dynect']['domain']}"
-  customer node['dynect']['customer']
-  username node['dynect']['username']
-  password node['dynect']['password']
+  customer creds['customer']
+  username creds['username']
+  password creds['password']
   zone node['dynect']['zone']
   action :update
 end

--- a/recipes/ec2.rb
+++ b/recipes/ec2.rb
@@ -18,15 +18,18 @@
 #
 
 include_recipe 'dynect'
+extend Dynect::Helper
+
+creds = get_credentials
 
 # "i-17734b7c.example.com" => ec2.public_hostname
 dynect_rr node['ec2']['instance_id'] do
   record_type 'CNAME'
   fqdn "#{node['ec2']['instance_id']}.#{node['dynect']['domain']}"
   rdata('cname' => "#{node['ec2']['public_hostname']}.")
-  customer node['dynect']['customer']
-  username node['dynect']['username']
-  password node['dynect']['password']
+  customer creds['customer']
+  username creds['username']
+  password creds['password']
   zone node['dynect']['zone']
   action :update
 end
@@ -38,9 +41,9 @@ dynect_rr new_hostname do
   record_type 'CNAME'
   fqdn new_fqdn
   rdata('cname' => "#{node['ec2']['public_hostname']}.")
-  customer node['dynect']['customer']
-  username node['dynect']['username']
-  password node['dynect']['password']
+  customer creds['customer']
+  username creds['username']
+  password creds['password']
   zone node['dynect']['zone']
   action :update
 end

--- a/spec/unit/recipes/a_record_spec.rb
+++ b/spec/unit/recipes/a_record_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'a_record recipe on Ubuntu 14.04' do
+  context 'with databag based configuration' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.set[:lsb][:codename] = 'trusty'
+        node.set['hostname'] = 'host'
+        node.set['ipaddress'] = '127.0.0.1'
+        node.set['dynect']['domain'] = 'example.com'
+        node.set['dynect']['zone'] = 'z'
+        node.set['dynect']['data_bag_name'] = 'passwords'
+        node.set['dynect']['data_bag_item'] = 'dynect'
+      end.converge('dynect::a_record')
+    end
+
+    before do
+      allow(Chef::EncryptedDataBagItem).to receive(:load).with('passwords', 'dynect').and_return({
+        'customer' => 'xavier',
+        'username' => 'yolanda',
+        'password' => 'zoolander'
+      })
+    end
+
+    it 'places an A record' do
+      expect(chef_run).to update_dynect_rr('chefspec').with(
+        record_type: 'A',
+        rdata: {
+          'address' => '127.0.0.1'
+        },
+        fqdn: 'chefspec.example.com',
+        customer: 'xavier',
+        username: 'yolanda',
+        password: 'zoolander',
+        zone: 'z'
+      )
+    end
+  end
+
+  context 'with inline configuration' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set[:lsb][:codename] = 'trusty'
+        node.set['ipaddress'] = '127.0.0.1'
+        node.set['dynect']['domain'] = 'example.com'
+        node.set['dynect']['customer'] = 'alice'
+        node.set['dynect']['username'] = 'bob'
+        node.set['dynect']['password'] = 'carol'
+        node.set['dynect']['zone'] = 'z'
+      end.converge('dynect::a_record')
+    end
+
+    it 'places an A record' do
+      expect(chef_run).to update_dynect_rr('chefspec').with(
+        record_type: 'A',
+        rdata: {
+          'address' => '127.0.0.1'
+        },
+        fqdn: 'chefspec.example.com',
+        customer: 'alice',
+        username: 'bob',
+        password: 'carol',
+        zone: 'z'
+      )
+    end
+  end
+end


### PR DESCRIPTION
As per best practice, this allows using an encrypted databag
to store Dynect creds. If the databag name is not set, the
cookbook reverts to the old behavior of looking in the node
attributes.